### PR TITLE
Allows for lazy swift connections

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -136,6 +136,19 @@ class ConfigTest(SwiftStorageTestCase):
         storage_url = '{}/v1/AUTH_{}/{}/'.format(url, TENANT_ID, "container")
         self.assertEqual(backend.base_url, storage_url)
 
+    def test_override_lazy_connect(self):
+        """Test setting lazy_connect"""
+        backend = self.default_storage('v3',
+                                       lazy_connect=True)
+        self.assertIsNone(backend.base_url)
+
+        # Run existence check to trigger connection
+        exists = backend.exists('warez/some_random_movie.mp4')
+        self.assertFalse(exists)
+
+        # Ensure that base_url is now set
+        self.assertEqual(backend.base_url, base_url(container="container"))
+
 
 @patch('swift.storage.swiftclient', new=FakeSwift)
 class TokenTest(SwiftStorageTestCase):


### PR DESCRIPTION
Instead of connecting to SWIFT on storage init, this change connects allows the connection to be lazy loaded when required.

Due to some recursion and race conditions with the `token` and `storage_url`, this change ended up being more complex than I initially planned.

**Sandbox URLs**

* LMS: https://smarnach-sandbox.opencraft.hosting/
* Studio: https://studio-smarnach-sandbox.opencraft.hosting/

**Testing Instructions**

1. Set up swift storage on your devstack/server.
1. Install this branch, and set `settings.SWIFT_LAZY_CONNECT = True` to activate the feature.
1. When starting edxapp, notice that no swift connections are made.
1. Upload a file to a discussion board post, and note that swift connections are made during this process.  File should upload to the configured SWIFT container as expected.

To run automated tests, run `tox`.

**Author Notes and Concerns**

* PR should be submitted to upstream master as well.  This change is based on `v1.2.15`, which is what is [currently used by edx-platform](https://github.com/edx/edx-platform/blob/master/requirements/edx/openstack.txt#L6).

**Reviewer**
- [ ] @smarnach 